### PR TITLE
Marking isSyncing as true, when a manualSync is kicked off. 

### DIFF
--- a/PingPong/BackgroundSync.swift
+++ b/PingPong/BackgroundSync.swift
@@ -69,6 +69,8 @@ public class BackgroundSync {
             print("Manual sync avoided, already running in background")
             return
         }
+		// Update the syncing status
+		self.isSyncing = true
         
         // Create some work for queue
         let someWork : ()->() = {


### PR DESCRIPTION
This ensures more than one manual sync can't be run at the same time.