### PR TITLE
Updated deprecated method calls + Resolved unwrapping error

### DIFF
--- a/PingPong/BackgroundSync.swift
+++ b/PingPong/BackgroundSync.swift
@@ -114,8 +114,8 @@ public class BackgroundSync {
         if let jsonDocuments = results {
             // For each document
             for json in jsonDocuments {
-                let type = JSON.parse(json)["docType"].stringValue
-                let id = JSON.parse(json)["id"].stringValue
+                let type = JSON.init(parseJSON: json)["docType"].stringValue
+                let id = JSON.init(parseJSON: json)["id"].stringValue
                 
                 // The success for each type of document is to remove itself from the sync queue
                 let success = {

--- a/PingPong/DataStore.swift
+++ b/PingPong/DataStore.swift
@@ -133,7 +133,7 @@ public class DataStore {
     }
     
     public func stashDocument(documentJson : String) {
-        let json = JSON.parse(documentJson)
+        let json = JSON.init(parseJSON: documentJson)
         
         if let id = json["id"].string {
             queue.inDatabase { (database) -> Void in
@@ -250,7 +250,7 @@ public class DataStore {
                 let results = try database.executeQuery("SELECT json FROM documents\(whereString)", values: searchValues)
                 
                 while (results.next()) {
-                    documents.append(JSON.parse(results.string(forColumn: "json")!))
+                    documents.append(JSON.init(parseJSON: results.string(forColumn: "json")!))
                 }
                 results.close()
             } catch {
@@ -269,7 +269,7 @@ public class DataStore {
                 let results = try database.executeQuery(query, values: nil)
                 
                 while (results.next()) {
-                    documents.append(JSON.parse(results.string(forColumn: "json")!))
+					documents.append(JSON.init(parseJSON: results.string(forColumn: "json")!))
                 }
                 results.close()
             } catch {

--- a/PingPong/DataStore.swift
+++ b/PingPong/DataStore.swift
@@ -29,7 +29,7 @@ public class DataStore {
         // Initialize the queue
         let appDir = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
         let dbPath = "\(appDir)/\(DataStore.databaseName)"
-        queue = FMDatabaseQueue(path: dbPath)
+        queue = FMDatabaseQueue(path: dbPath)!
     }
     
     public func stashObjects(objects: [StashObject]) -> Bool{
@@ -343,7 +343,7 @@ public class DataStore {
         try! FileManager.default.removeItem(atPath: dbPath)
         
         // Initialize the queue
-        queue = FMDatabaseQueue(path: dbPath)
+        queue = FMDatabaseQueue(path: dbPath)!
         
         // Get and unwrap instance of BRDatabase
         let sharedDatabase = BRDatabase.sharedBRDatabase

--- a/PingPong/JsonObject.swift
+++ b/PingPong/JsonObject.swift
@@ -128,7 +128,7 @@ open class JsonObject : NSObject {
     
     // Init object with json string
     open func fromJSON(json : String) {
-        self.fromSwiftyJSON(json: JSON.parse(json))
+		self.fromSwiftyJSON(json: JSON.init(parseJSON: json))
     }
     
     private func fromSwiftyJSON(json : JSON) {

--- a/PingPong/PingPong.swift
+++ b/PingPong/PingPong.swift
@@ -227,7 +227,7 @@ public class PingPong {
     // POST JSON Document
     public func saveDocumentToCloud(jsonString : String, success : (() -> ())? ) {
         // Guard against missing id
-        guard let id = JSON.parse(jsonString)["id"].string else {
+        guard let id = JSON.init(parseJSON: jsonString)["id"].string else {
             return
         }
         
@@ -256,7 +256,7 @@ public class PingPong {
                 if (httpResponse.statusCode >= 200 && httpResponse.statusCode < 300) {
                     // Parse the data
                     if let realData = data, let value = String(data: realData, encoding: String.Encoding.utf8) {
-                        let json = JSON.parse(value)
+                        let json = JSON.init(parseJSON: value)
                         if let documentJson = json["data"].rawString() {
                             // Update stash
                             DataStore.sharedDataStore.stashDocument(documentJson: documentJson)


### PR DESCRIPTION
**Straightforward**
-Updated `JSON.parse` calls to `JSON.init(parseJSON...` since the former had been deprecated and removed. This was causing build issues on a new project implementation.

**Not-So-Straightforward**
-In Datastore.m the line `queue = FMDatabaseQueue(path: dbPath)` is fine, but on a new Swift 4.2 project, the compiler sees the returned variable as an optional and asks to force unwrap it. Though i've added this as a fix to the current commit, I don't think this can be safely merged in the existing code, because it'll cause issues with current projects if they update their PingPong version from this repo. We need to figure out a good way to do this.

Right now in the new project, i am using my fork as the PingPong repo source temporarily.